### PR TITLE
Expand embedding model allowlist with code-optimized models

### DIFF
--- a/src/embeddings/model.py
+++ b/src/embeddings/model.py
@@ -4,17 +4,26 @@ import os
 ALLOWED_MODELS = {
     "all-MiniLM-L6-v2",
     "all-mpnet-base-v2",
+    "jinaai/jina-embeddings-v2-base-code",
+    "microsoft/codebert-base",
+    "flax-sentence-embeddings/st-codesearch-distilroberta-base",
+    "Salesforce/codet5p-110m-embedding",
 }
 
-# load model version from env
+# models that require non-standard loader kwargs
+_MODEL_KWARGS: dict[str, dict] = {
+    "jinaai/jina-embeddings-v2-base-code": {"trust_remote_code": True},
+}
+
 MODEL: str = os.getenv("MODEL", "all-MiniLM-L6-v2")
 if MODEL not in ALLOWED_MODELS:
     raise ValueError(f"Model {MODEL} is not in the allowlist")
 
 device = os.getenv("DEVICE", "cpu")
 
-# Load model at module import time
-_model: SentenceTransformer = SentenceTransformer(MODEL, device=device)
+_model: SentenceTransformer = SentenceTransformer(
+    MODEL, device=device, **_MODEL_KWARGS.get(MODEL, {})
+)
 
 
 def get_model() -> SentenceTransformer:


### PR DESCRIPTION
## Summary

- Adds 4 code-optimized models to `ALLOWED_MODELS` in `src/embeddings/model.py`
- Introduces `_MODEL_KWARGS` to pass model-specific loader arguments (e.g. `trust_remote_code=True` required by Jina)
- No other code changes — chunk size, overlap, device, and model selection remain fully env-configurable

## New models

| Model | Dims | Context | Notes |
|---|---|---|---|
| `jinaai/jina-embeddings-v2-base-code` | 768 | 8192 tokens | Best for NL→code retrieval; requires `trust_remote_code=True` |
| `microsoft/codebert-base` | 768 | 512 tokens | Trained on NL+code pairs (CodeSearchNet) |
| `flax-sentence-embeddings/st-codesearch-distilroberta-base` | 768 | 512 tokens | Fine-tuned on CodeSearchNet, fast |
| `Salesforce/codet5p-110m-embedding` | 256 | 512 tokens | Smallest/fastest code embedding option |

## Recommended `.env` for code workloads

```
MODEL="jinaai/jina-embeddings-v2-base-code"
CHUNK_SIZE=1000
OVERLAP=200
```

## Test plan

- [ ] `docker compose up` with default `MODEL=all-MiniLM-L6-v2` — verify existing behaviour unchanged
- [ ] Restart with `MODEL=jinaai/jina-embeddings-v2-base-code` — verify model loads without error
- [ ] Upload a source file and run a natural language search query — verify results returned
- [ ] Set `MODEL=invalid-model` — verify `ValueError` is raised on startup

---
_Generated by [Claude Code](https://claude.ai/code/session_018DUoTYx5ESnEp5f4ZkXMp9)_